### PR TITLE
Fixed use of sizeof (Use it on a pointer is illegal)

### DIFF
--- a/main.c
+++ b/main.c
@@ -73,7 +73,7 @@ dump_eeprom(st_srx_tag_t *dest, bool verbose) {
     fprintf(stderr, "Reading %d blocks\n|", tag_length);
     for (uint8_t i = 0; i < tag_length; i++) {
         uint8_t *block_dest = dest->raw_bytes + i * 4;
-        if (st_srx_read_block(pnd, block_dest, i, verbose) <= 0) {
+        if (st_srx_read_block(pnd, block_dest, sizeof(uint8_t) * 4, i, verbose) <= 0) {
             nfc_perror(pnd, "nfc_initiator_transceive_bytes");
             nfc_close(pnd);
             nfc_exit(context);
@@ -86,7 +86,7 @@ dump_eeprom(st_srx_tag_t *dest, bool verbose) {
 
     fprintf(stderr, "Reading system area block (0xFF)\n");
     uint8_t *block_dest = dest->raw_bytes + 0xff * 4;
-    if (st_srx_read_block(pnd, block_dest, 0xff, verbose) <= 0) {
+    if (st_srx_read_block(pnd, block_dest, sizeof(uint8_t) * 4, 0xff, verbose) <= 0) {
         nfc_perror(pnd, "nfc_initiator_transceive_bytes");
         nfc_close(pnd);
         nfc_exit(context);
@@ -186,7 +186,7 @@ write_eeprom(st_srx_tag_t *src, bool verbose) {
     for (uint8_t i = 0; i < tag_length; i++) {
         uint8_t *block_src = src->raw_blocks[i];
 
-        if (st_srx_read_block(pnd, abtRx, i, verbose) <= 0) {
+        if (st_srx_read_block(pnd, abtRx, sizeof(abtRx), i, verbose) <= 0) {
             nfc_perror(pnd, "nfc_initiator_transceive_bytes");
             nfc_close(pnd);
             nfc_exit(context);
@@ -194,7 +194,7 @@ write_eeprom(st_srx_tag_t *src, bool verbose) {
         }
 
         if (memcmp(block_src, abtRx, 4) != 0) {
-            if (st_srx_write_block(pnd, abtRx, i, block_src, verbose) <= 0) {
+            if (st_srx_write_block(pnd, abtRx, sizeof(abtRx), i, block_src, verbose) <= 0) {
                 nfc_perror(pnd, "nfc_initiator_transceive_bytes");
                 nfc_close(pnd);
                 nfc_exit(context);
@@ -210,14 +210,14 @@ write_eeprom(st_srx_tag_t *src, bool verbose) {
 
     fprintf(stderr, "Writing system area block (0xFF)\n");
     uint8_t *block_src = src->srix4k.system_block;
-    if (st_srx_read_block(pnd, abtRx, 0xFF, verbose) <= 0) {
+    if (st_srx_read_block(pnd, abtRx, sizeof(abtRx), 0xFF, verbose) <= 0) {
         nfc_perror(pnd, "nfc_initiator_transceive_bytes");
         nfc_close(pnd);
         nfc_exit(context);
         return EXIT_FAILURE;
     }
     if (memcmp(block_src, abtRx, 4) != 0) {
-        if (st_srx_write_block(pnd, abtRx, 0xFF, block_src, verbose) <= 0) {
+        if (st_srx_write_block(pnd, abtRx, sizeof(abtRx), 0xFF, block_src, verbose) <= 0) {
             nfc_perror(pnd, "nfc_initiator_transceive_bytes");
             nfc_close(pnd);
             nfc_exit(context);
@@ -362,7 +362,7 @@ main(int argc, const char *argv[]) {
 
     // Try to retrieve the UID using the SRx protocol to confirm it's working
     fprintf(stderr, "Found ISO14443B-2 tag, UID:\n");
-    size_t received_bytes = st_srx_get_uid(pnd, abtRx, true);
+    size_t received_bytes = st_srx_get_uid(pnd, abtRx, sizeof(abtRx), true);
     if (received_bytes <= 0) {
         fclose(dump_fd);
         ERR("Failed to retrieve the UID");

--- a/nfc-utils.c
+++ b/nfc-utils.c
@@ -69,7 +69,7 @@ print_nfc_target(const nfc_target *pnt, bool verbose) {
 }
 
 size_t
-transceive_bytes(nfc_device *pnd, const uint8_t *pbtTx, uint8_t *pbtRx, const size_t szTx, bool verbose) {
+transceive_bytes(nfc_device *pnd, const uint8_t *pbtTx, uint8_t *pbtRx, const size_t szTx, const size_t szRx, bool verbose) {
     if (verbose) {
         // Show transmitted command
         fprintf(stderr, "Sent bits:     ");
@@ -79,7 +79,7 @@ transceive_bytes(nfc_device *pnd, const uint8_t *pbtTx, uint8_t *pbtRx, const si
     // Transmit the command bytes
     size_t res;
 
-    if ((res = nfc_initiator_transceive_bytes(pnd, pbtTx, szTx, pbtRx, sizeof(pbtRx), 0)) < 0)
+    if ((res = nfc_initiator_transceive_bytes(pnd, pbtTx, szTx, pbtRx, szRx, 0)) < 0)
         return false;
 
     if (verbose) {

--- a/nfc-utils.h
+++ b/nfc-utils.h
@@ -95,6 +95,6 @@
 
 void print_hex(const uint8_t *pbtData, size_t szLen);
 void print_nfc_target(const nfc_target *pnt, bool verbose);
-size_t transceive_bytes(nfc_device *pnd, const uint8_t *pbtTx, uint8_t *pbtRx, size_t szTx, bool verbose);
+size_t transceive_bytes(nfc_device *pnd, const uint8_t *pbtTx, uint8_t *pbtRx, size_t szTx, size_t szRx, bool verbose);
 
 #endif

--- a/st-srx.c
+++ b/st-srx.c
@@ -9,23 +9,23 @@
 
 
 size_t
-st_srx_get_uid(nfc_device *pnd, uint8_t *uidRx, bool verbose) {
+st_srx_get_uid(nfc_device *pnd, uint8_t *uidRx, const size_t szUid, bool verbose) {
     uint8_t cmd[] = {0x0b};
-    return transceive_bytes(pnd, (const uint8_t *) &cmd, uidRx, sizeof(cmd), verbose);
+    return transceive_bytes(pnd, (const uint8_t *) &cmd, uidRx, sizeof(cmd), szUid, verbose);
 }
 
 
 size_t
-st_srx_read_block(nfc_device *pnd, uint8_t *blockRx, uint8_t address, bool verbose) {
+st_srx_read_block(nfc_device *pnd, uint8_t *blockRx, const size_t szRead, uint8_t address, bool verbose) {
     uint8_t cmd[2] = {0x08};
     memcpy(cmd + 1, &address, 1);
-    return transceive_bytes(pnd, (const uint8_t *) &cmd, blockRx, sizeof(cmd), verbose);
+    return transceive_bytes(pnd, (const uint8_t *) &cmd, blockRx, sizeof(cmd), szRead, verbose);
 }
 
 size_t
-st_srx_write_block(nfc_device *pnd, uint8_t *blockRx, uint8_t address, uint8_t *data, bool verbose) {
+st_srx_write_block(nfc_device *pnd, uint8_t *blockRx, const size_t szWrite, uint8_t address, uint8_t *data, bool verbose) {
     uint8_t cmd[6] = {0x09};
     memcpy(cmd + 1, &address, 1);
     memcpy(cmd + 2, data, 4);
-    return transceive_bytes(pnd, (const uint8_t *) &cmd, blockRx, sizeof(cmd), verbose);
+    return transceive_bytes(pnd, (const uint8_t *) &cmd, blockRx, sizeof(cmd), szWrite, verbose);
 }

--- a/st-srx.h
+++ b/st-srx.h
@@ -31,8 +31,8 @@ typedef union {
     uint8_t raw_blocks[DUMP_LEN][4];
 } st_srx_tag_t;
 
-size_t st_srx_get_uid(nfc_device *pnd, uint8_t *uidRx, bool verbose);
-size_t st_srx_read_block(nfc_device *pnd, uint8_t *blockRx, uint8_t address, bool verbose);
-size_t st_srx_write_block(nfc_device *pnd, uint8_t *blockRx, uint8_t address, uint8_t *data, bool verbose);
+size_t st_srx_get_uid(nfc_device *pnd, uint8_t *uidRx, size_t szUid, bool verbose);
+size_t st_srx_read_block(nfc_device *pnd, uint8_t *blockRx, size_t szRead, uint8_t address, bool verbose);
+size_t st_srx_write_block(nfc_device *pnd, uint8_t *blockRx, size_t szWrite, uint8_t address, uint8_t *data, bool verbose);
 
 #endif //NFC_ST_SRX_ST_SRX_H


### PR DESCRIPTION
Before there was a sizeof(rxPtr) but that is illegal because in this way you are getting the size of the pointer.
In a 64 bit pc it will be 8 byte (64 bit), but on a 32 bit it will be 4.
So you say to libnfc that the destination array has a length of 4 bytes.
The UID length is 8 byte so if you read it on a 32 bit pc and say to libnfc that the destination length is 4, there will be an error.
So i fixed it and now there is the effective length.